### PR TITLE
Update CONTRIBUTING.md: add milestone assignment to house rules

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contribution & Labeling Guidelines
+
+Welcome to the WebDev project! To keep our workflow sharp, scalable, and easy for everyone, please follow these simple rules for labeling and milestones:
+
+## Labeling Guidelines
+
+- **Each issue must have exactly one `type:*` label.**
+  - `type:Feature`
+  - `type:Bug`
+  - `type:Tech-debt`
+  - `type:NFR`
+  - `type:Spike`
+
+- **Each issue may have at most one `Pri:*` label.**
+  - `Pri:Must`
+  - `Pri:Should`
+  - `Pri:Could`
+  - `Pri:Won’t`
+
+- **Triage labels are temporary and should be removed once resolved.**
+  - `duplicate`, `invalid`, `question`, `help wanted`
+
+## Why this system?
+- One clear axis per label family—no overlap, no confusion.
+- Consistent naming (`type:`, `Pri:`) makes filtering, automation, and onboarding easy.
+- No “status:in progress” or vibes-based priorities—just clear, actionable labels.
+
+## Milestones
+- Milestones should map to major deliverables, sprints, or roadmap goals.
+- Pair `Pri:*` labels with milestones for clear prioritization.
+
+**Current Milestone Conventions:**
+- `Phase 1` (MVP): Minimum viable product, must-have features for launch.
+- `Phase 2` (MVP +1): Next set of improvements and enhancements after MVP.
+- `Phase Future` (Undefined timeline): Ideas and features for the long-term roadmap, not yet scheduled.
+
+## House Rules
+1. Each issue must have exactly one `type:*` label.
+2. Each issue may have at most one `Pri:*` label.
+3. Triage labels are for temporary use only.
+4. Each issue should be assigned to a milestone (`Phase 1`, `Phase 2`, or `Phase Future`) to clarify its place in the roadmap.
+
+Keep it boring, sharp, and effective. If you have questions, open an issue or ask in the project discussion!


### PR DESCRIPTION
This pull request updates the CONTRIBUTING.md file to clarify and strengthen our project workflow:

- Adds a new house rule: each issue should be assigned to a milestone (`Phase 1`, `Phase 2`, or `Phase Future`) to clarify its place in the roadmap.
- Ensures all contributors follow consistent labeling, prioritization, and milestone assignment.
- Keeps our process sharp, scalable, and easy to onboard new team members.

These changes help everyone understand expectations and keep the project organized as it grows.